### PR TITLE
Fix "location" spelling

### DIFF
--- a/hackathon/templates/index.html
+++ b/hackathon/templates/index.html
@@ -31,7 +31,7 @@
                             February, 2025
                         </h1>
                         <h1>
-                            Locaiton TBD @ RIT
+                            Location TBD @ RIT
                         </h1>
                         <h1>
                             Click <a href="/register">here</a> to register!


### PR DESCRIPTION
Pretty self explanatory, fix the spelling of "location" on the homepage